### PR TITLE
Added check for the .k5login file

### DIFF
--- a/src/system/authsettings/group.xml
+++ b/src/system/authsettings/group.xml
@@ -278,5 +278,35 @@
         <check-content-ref href="zero_uid_root.sh" />
       </check>
     </Rule>
+    <Rule id="xccdf_org.open-scap.sce-community-content_rule_system_authsettings-k5login_file_permissions" selected="true">
+      <title>Check the permissions of .k5login files</title>
+      <description>
+        <xhtml:p>The permission of any user's .k5login must be set to 0644.</xhtml:p>
+        <xhtml:p>If a .k5login file is writable by a group-owner or the world the risk of its compromise is increased. The file contains the list of Kerberos accounts which can login as a given user. Various tools require read-only access to this file; write protection of this file is critical for user security.</xhtml:p>
+        <xhtml:p>
+          File(s) affected:
+          <xhtml:ul>
+            <xhtml:li>/home/*/.k5login</xhtml:li>
+          </xhtml:ul>
+        </xhtml:p>
+      </description>
+      <fix system="urn:xccdf:fix:script:sh">
+        while read user home
+        do
+        if [ -e $home/.k5login ]
+          then
+              chmod -R 0644 $home/.k5login
+              chown -R $user $home/.k5login
+          fi
+        done &lt;&lt;_EOF
+        $(grep -v /sbin/nologin /etc/passwd | cut -d: -f 1,6 | tr ':' ' ')
+_EOF
+
+      </fix>
+      <check system="http://open-scap.org/page/SCE">
+        <check-import import-name="stdout" />
+        <check-content-ref href="k5login_file_permissions.sh" />
+      </check>
+    </Rule>
   </Group>
 </xf:xccdf-fragment>

--- a/src/system/authsettings/k5login_file_permissions.sh
+++ b/src/system/authsettings/k5login_file_permissions.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+RET=$XCCDF_RESULT_PASS
+
+while read user home shell
+do
+    if [ "x$shell" == "x/sbin/nologin" ]
+    then
+        continue
+    fi
+
+    if [ -e $home/.k5login ]
+    then
+        if [ "x$(find $home/.k5login -perm /055 -maxdepth 0)" != "x" ]
+        then
+            echo "$home/.k5login has invalid permissions set"
+            RET=$XCCDF_RESULT_FAIL
+        fi
+
+        if [ "x$(stat -c '%U' $home/.k5login)" != "x$user" ]
+        then
+            echo "$home/.k5login has invalid owner"
+            RET=$XCCDF_RESULT_FAIL
+        fi
+    fi
+
+done <<EOF
+$(cat /etc/passwd | cut -d ':' -f 1,6,7 | tr ':' ' ')
+EOF
+
+exit $RET
+


### PR DESCRIPTION
Based on the openssh protections, I've added this check for Kerberos .k5login files.  Since this was authentication related I placed it under the 'auth' group.